### PR TITLE
Remove Restart Identity from SQL query, removes slack references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
     DUNE_API_KEY=
     DUNE_QUERY_ID=
     GITHUB_API_KEY=
-    SLACK_URL=
     DB_HOST=
     DB_NAME=
     DB_USER=
@@ -63,7 +62,6 @@ Currently, resources in Azure are created and managed manually with the pipeline
 ```angular2html
 RPC_URL=
 ETHERSCAN_API_KEY=
-SLACK_URL=
 ```
 
 2) `pip install -r "requirements.txt"`

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,10 +34,7 @@ ARBISCAN_API_KEY = os.getenv("ARBISCAN_API_KEY")
 BASESCAN_API_KEY = os.getenv("BASESCAN_API_KEY")
 DUNE_API_KEY = os.getenv("DUNE_API_KEY")
 DUNE_QUERY_ID = os.getenv("DUNE_QUERY_ID")
-SLACK_URL = os.getenv("SLACK_URL")
 GITHUB_API_KEY = os.getenv("GITHUB_API_KEY")
-
-NOTIFICATION_CHANNEL = "slack-example-channel"
 
 web3 = Web3(Web3.HTTPProvider(ETH_RPC_URL))
 web3_arb = Web3(Web3.HTTPProvider(ARB_RPC_URL))

--- a/app/repository/user_multiplier_repository.py
+++ b/app/repository/user_multiplier_repository.py
@@ -293,7 +293,7 @@ class UserMultiplierRepository(BaseRepository[UserMultiplier]):
     
     def clean_table(self) -> bool:
         sql = f"""
-        TRUNCATE TABLE {self.table_name} RESTART IDENTITY
+        TRUNCATE TABLE {self.table_name}
         """
 
         with self.db.transaction() as cursor:

--- a/docs/UpdateCirculatingSupply.md
+++ b/docs/UpdateCirculatingSupply.md
@@ -43,7 +43,6 @@ This script tracks and updates the circulating supply of a cryptocurrency token 
 2. **Error Handling**
    - Catches and logs blockchain-related exceptions like `BlockNotFound`
    - Implements comprehensive error logging throughout the process
-   - Provides operational notifications via Slack
    - Ensures database transaction integrity
 
 ## Data Structure

--- a/docs/UpdateOverplusBridgedEvents.md
+++ b/docs/UpdateOverplusBridgedEvents.md
@@ -71,7 +71,6 @@ This script tracks and processes `OverplusBridged` events from an Ethereum block
    - Cleans up temporary files
 
 4. **Notification**
-   - Includes (currently commented-out) Slack notification functionality
    - Logs key actions and errors for monitoring
 
 ## Specific Features

--- a/docs/UpdateTotalDailyRewards.md
+++ b/docs/UpdateTotalDailyRewards.md
@@ -35,7 +35,6 @@ This script calculates and tracks daily and total user rewards from an Ethereum 
    - Downloads input data from "UserMultiplier" sheet
    - Uploads summary results to "RewardSum" sheet
    - Clears existing data before uploading new records
-   - Sends Slack notifications about operation status
 
 ## Technical Requirements
 
@@ -47,7 +46,6 @@ This script calculates and tracks daily and total user rewards from an Ethereum 
    - `web3`: For Ethereum blockchain interaction (AsyncWeb3 variant)
    - Custom modules:
      - `configuration.config`: For RPC URL, contract information, API keys, and spreadsheet ID
-     - `sheet_config.google_utils`: For Google Sheets operations and Slack notifications
 
 2. **API Requirements**
    - Ethereum RPC endpoint for blockchain interaction
@@ -57,7 +55,6 @@ This script calculates and tracks daily and total user rewards from an Ethereum 
 3. **Error Handling**
    - Retry mechanism for rate-limited API calls (maximum 3 attempts with 5-second delay)
    - Comprehensive logging
-   - Error notifications via Slack
    - Temporary file cleanup even if errors occur
 
 ## Implementation Details

--- a/docs/UpdateUserClaimLockedEvents.md
+++ b/docs/UpdateUserClaimLockedEvents.md
@@ -51,7 +51,6 @@ This script is designed to track and process `UserClaimLocked` events from an Et
 
 - The main execution code is commented out (`if __name__ == "__main__"`)
 - Functions for uploading data to Google Sheets are commented out
-- There's a commented-out reference to Slack notifications for operation status reporting
 
 ## Data Flow
 1. Download existing data from Google Sheets

--- a/docs/UpdateUserMultipliers.md
+++ b/docs/UpdateUserMultipliers.md
@@ -26,7 +26,6 @@ This script processes blockchain data to calculate and record user multipliers f
    - Downloads input data from "UserClaimLocked" sheet
    - Uploads results to "UserMultiplier" sheet
    - Clears existing data before uploading new records
-   - Sends Slack notifications about operation status
 
 ## Technical Requirements
 
@@ -38,7 +37,6 @@ This script processes blockchain data to calculate and record user multipliers f
    - `decimal`: For precise handling of large numbers
    - Custom modules:
      - `configuration.config`: For RPC URL, contract information, and spreadsheet ID
-     - `sheet_config.google_utils`: For Google Sheets operations and Slack notifications
 
 2. **Configuration Requirements**
    - Ethereum RPC URL (`ETH_RPC_URL`)
@@ -49,7 +47,6 @@ This script processes blockchain data to calculate and record user multipliers f
 3. **Error Handling**
    - Retry mechanism for rate-limited API calls (maximum 3 attempts)
    - Comprehensive error logging
-   - Error notifications via Slack
    - Temporary file cleanup in the finally block
 
 ## Implementation Details

--- a/docs/UpdateUserStakedEvents.md
+++ b/docs/UpdateUserStakedEvents.md
@@ -72,7 +72,6 @@ This script tracks and processes `UserStaked` events from an Ethereum blockchain
    - Cleans up temporary files
 
 4. **Notification**
-   - Includes (currently commented-out) Slack notification functionality
    - Logs key actions and errors for monitoring
 
 ## Operational Notes

--- a/docs/UpdateUserWithdrawnEvent.md
+++ b/docs/UpdateUserWithdrawnEvent.md
@@ -72,7 +72,6 @@ This script tracks and processes `UserWithdrawn` events from an Ethereum blockch
    - Cleans up temporary files
 
 4. **Notification**
-   - Includes (currently commented-out) Slack notification functionality
    - Logs key actions and errors for monitoring
 
 ## Operational Notes

--- a/helpers/supply_helpers/supply_main.py
+++ b/helpers/supply_helpers/supply_main.py
@@ -301,7 +301,6 @@ async def get_mor_holders():
     except DuneError as e:
         error_message = f"API Limit hit for Dune. Please rotate environment variables. Error: {str(e)}"
         logger.exception(f"An error occurred in get_mor_holders: {str(e)}")
-        slack_notification(error_message)
         return None
     except Exception as e:
         logger.exception(f"An error occurred in get_mor_holders: {str(e)}")


### PR DESCRIPTION
Can't seed the database totally as subabase doesn't allow RESTART IDENTITY in queries and I can't grant permissions for it to our user, so this was removed. Also removed slack references that were failing when running the Dune query.